### PR TITLE
TECH Update to handle for_each operator

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,10 +132,11 @@ resource "google_compute_http_health_check" "default" {
 
 # Create firewall rule for each backend in each network specified, uses mod behavior of element().
 resource "google_compute_firewall" "default-hc" {
-  count         = length(var.firewall_networks)
-  project       = var.firewall_projects[count.index] == "default" ? var.project : var.firewall_projects[count.index]
-  name          = "${var.name}-hc-${count.index}"
-  network       = var.firewall_networks[count.index]
+  for_each      = var.firewall_networks
+
+  project       = each.value == "default" ? var.project : each.value
+  name          = "${var.name}-hc-${each.value}"
+  network       = each.value
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"]
   target_tags   = var.target_tags
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,7 +16,7 @@
 
 output "backend_services" {
   description = "The backend service resources."
-  value       = google_compute_backend_service.default.*.self_link
+  value       = [for backend_service in google_compute_backend_service.default : backend_service.self_link]
 }
 
 output "external_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,14 +50,8 @@ variable "target_tags" {
   type        = list(string)
 }
 
-variable "backends" {
-  description = "Map backend indices to list of backend maps."
-  type        = map(any)
-}
-
-variable "backend_params" {
-  description = "List of backend parameters in a map with keys: healthcheck_path, service_name, service_port, timeout"
-  type        = list(any)
+variable "backend_services" {
+  description = "Map of backend services to create"
 }
 
 variable "backend_protocol" {
@@ -115,4 +109,3 @@ variable "cdn" {
   description = "Set to `true` to enable cdn on backend."
   default     = "false"
 }
-


### PR DESCRIPTION
Update module terraform-google-lb-http : 
- handle backend services creation with 'for_each' operator
- handle security policy per backend service
- handle timeout_sec and check_interval_sec for google_compute_http_health_check

**EDIT:**

Example of how the `backend_services` attribute looks : 
```
  backend_services = {
    "prometheus" = {
      healthcheck_path = "/metrics",
      service_name = "http",
      service_port = "9090",
      timeout = "86400",
      backends = [
        {
          group                 = data.google_compute_instance_group.prom-0.self_link
          balancing_mode        = "RATE"
          max_rate_per_instance = 1000000
        },
        {
          group                 = data.google_compute_instance_group.prom-1.self_link
          balancing_mode        = "RATE"
          max_rate_per_instance = 1000000
        },
        {
          group                 = data.google_compute_instance_group.prom-2.self_link
          balancing_mode        = "RATE"
          max_rate_per_instance = 1000000
        },
      ],
    },

    "rundeck" = {
      healthcheck_path = "/user/login",
      service_name = "http",
      service_port = "80",
      timeout = "86400",
      security_policy = null,
      backends = [
        {
          group                 = data.google_compute_instance_group.rundeck-0.self_link
          balancing_mode        = "RATE"
          max_rate_per_instance = 1000000
        },
      ],
    }
  }
```